### PR TITLE
Validation on date time columns before insert

### DIFF
--- a/clickhouse_driver/columns/datetimecolumn.py
+++ b/clickhouse_driver/columns/datetimecolumn.py
@@ -6,6 +6,7 @@ from tzlocal import get_localzone
 from .base import FormatColumn
 
 EPOCH = datetime(1970, 1, 1, tzinfo=utc)
+MAX_EPOCH_DATETIME = datetime(2106, 2, 7, 6, 28, 15, tzinfo=utc)
 
 
 class DateTimeColumn(FormatColumn):

--- a/clickhouse_driver/columns/service.py
+++ b/clickhouse_driver/columns/service.py
@@ -1,7 +1,8 @@
+from pytz import utc
 from .. import errors
 from .arraycolumn import create_array_column
 from .datecolumn import DateColumn, Date32Column
-from .datetimecolumn import create_datetime_column
+from .datetimecolumn import create_datetime_column, EPOCH, MAX_EPOCH_DATETIME
 from .decimalcolumn import create_decimal_column
 from . import exceptions as column_exceptions
 from .enumcolumn import create_enum_column
@@ -109,6 +110,12 @@ def write_column(context, column_name, column_spec, items, buf,
     column = get_column_by_spec(column_spec, column_options)
 
     try:
+        if column_spec.startswith('DateTime'):
+            items = [EPOCH if item is None else item.astimezone(utc) for item in items]
+
+            if column_spec == 'DateTime':
+                items = [min(item, MAX_EPOCH_DATETIME) for item in items]
+
         column.write_state_prefix(buf)
         column.write_data(items, buf)
 

--- a/clickhouse_driver/columns/service.py
+++ b/clickhouse_driver/columns/service.py
@@ -1,7 +1,7 @@
 from pytz import utc
 from .. import errors
 from .arraycolumn import create_array_column
-from .datecolumn import DateColumn, Date32Column
+from .datecolumn import DateColumn, Date32Column, epoch_start, epoch_end, epoch_start_date32, epoch_end_date32
 from .datetimecolumn import create_datetime_column, EPOCH, MAX_EPOCH_DATETIME
 from .decimalcolumn import create_decimal_column
 from . import exceptions as column_exceptions
@@ -110,9 +110,14 @@ def write_column(context, column_name, column_spec, items, buf,
     column = get_column_by_spec(column_spec, column_options)
 
     try:
-        if column_spec.startswith('DateTime'):
-            items = [EPOCH if item is None else item.astimezone(utc) for item in items]
+        if column_spec == 'Date':
+            items = [epoch_start if item is None else min(item, epoch_end) for item in items]
 
+        elif column_spec == 'Date32':
+            items = [epoch_start_date32 if item is None else min(item, epoch_end_date32) for item in items]
+
+        elif column_spec.startswith('DateTime'):
+            items = [EPOCH if item is None else item.astimezone(utc) for item in items]
             if column_spec == 'DateTime':
                 items = [min(item, MAX_EPOCH_DATETIME) for item in items]
 


### PR DESCRIPTION
# ✨ Feature 
## Background
Added following checks and transformations:
* When inserting into Date, Date32, DateTime or DateTime64, transform fill None with default date value
* When inserting into DateTime, Date and Date32, cap all values to the maximum of epoch


## Test CASES
* End to End Initial Migration on Patrik Staging  ( ✅  @Nicky027 )
  * Rows having StartDate = 0 get inserted
  * Rows having EndDate with values as big as 2120-09-30 09:46:01 get capped to the max epoch
  * Rows having "well-behaved" datetimes, retain the correct value

## Risk Classification
[LOW]
New service

## Affected Systems & Partners
MySQL-ClickHouse Shipper

## PARTNERS
All

## Release Assessment
| Description                                                            | Checked |
|------------------------------------------------------------------------|---------|
| I have prepared release notes (to describe the change)                 |  ✅      |
| Thoroughly considered key test cases and what can go wrong             |      ✅    |
| Based on this classified wether its a low, medium or high risk release |     ✅     |
| Identified which partners and systems are affected by my release       |    ✅      |

 

# Dependencies for the release
* N/A
